### PR TITLE
Allow specifying the width/height for `resizeWindow`

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,12 +57,14 @@ View.prototype.cameraVector = function() {
 }
 
 View.prototype.resizeWindow = function(width, height) {
-  if( this.element.parentElement ) {
-    width = this.element.parentElement.clientWidth
-    height = this.element.parentElement.clientHeight
+  if (this.element.parentElement) {
+    width = width || this.element.parentElement.clientWidth
+    height = height || this.element.parentElement.clientHeight
   }
 
   this.camera.aspect = this.aspectRatio = width/height
+  this.width = width
+  this.height = height
 
   this.camera.updateProjectionMatrix()
 

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
   "readme": "view functionality for voxeljs",
   "dist": {
     "shasum": "2a2c75b27d8c9f79570584267f5ddf2c4e6e1150"
-  },
+  }
 }


### PR DESCRIPTION
`resizeWindow` was ignoring its arguments when a view's element was attached to the DOM, and falling back to the width/height of its parent. This meant when the window was resized in most examples it would resize horizontally but not vertically. Here's a fix for that :)
