### PR TITLE
three.js r57 + r58 compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ View.prototype.cameraPosition = function() {
 View.prototype.cameraVector = function() {
   temporaryVector.multiplyScalar(0)
   temporaryVector.z = -1
-  this.camera.matrixWorld.rotateAxis(temporaryVector)
+  temporaryVector.transformDirection( this.camera.matrixWorld )
   return [temporaryVector.x, temporaryVector.y, temporaryVector.z]
 }
 


### PR DESCRIPTION
I _think_ this is the only thing needed to avoid deprecation warnings in the newer three.js
