### PR TITLE
bump package ver to 0.0.7 for three r56,58 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voxel-view",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "a default camera & renderer for voxeljs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Makes the update in https://github.com/snagy/voxel-view/commit/c769bca9b3eb525cdbd5ece66e83dc343909ba22 available on npm.
