### PR TITLE
Turn on gammaInput, gammaOutput and physicalBasedShading

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,9 @@ View.prototype.createRenderer = function(opts) {
   this.renderer = new THREE.WebGLRenderer(opts)
   this.renderer.setSize(this.width, this.height)
   this.renderer.setClearColorHex(this.skyColor, 1.0)
+  this.renderer.gammaInput = opts.gammaInput !== false
+  this.renderer.gammaOutput = opts.gammaOutput !== false
+  this.renderer.physicallyBasedShading = opts.physicallyBasedShading !== false
   this.renderer.clear()
 }
 


### PR DESCRIPTION
I think it's a good idea to enable physical based shading by default as it generally makes things look subtly better with little to no performance hit:
![gamma](https://f.cloud.github.com/assets/99604/650978/a870e846-d468-11e2-8179-74729bcb4dde.png)
