### PR TITLE
Make skyColor apply to both sky and fog

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ View.prototype.createRenderer = function(opts) {
   this.renderer = new THREE.WebGLRenderer(opts)
   this.renderer.setSize(this.width, this.height)
   this.renderer.setClearColorHex(this.skyColor, 1.0)
-  this.renderer.clear()
+  this.renderer.clear(this.renderer.getClearColor())
 }
 
 View.prototype.bindToScene = function(scene) {


### PR DESCRIPTION
Skycolor seems to only set fog color, not actual sky color

Passing the clear color manually into the renderer.clear function here makes the sky color apply. This might be a quirk of the dependent version of three.js used in voxel-engine (which is quite a bit out of date), but passing the parameter in explicitly won't do harm in any case
